### PR TITLE
fix: remove type: module to support CommonJS consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frantisekstanko/assertion",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frantisekstanko/assertion",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@frantisekstanko/assertion",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Type-safe assertion library for TypeScript",
-  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Allows Jest and other CommonJS-based tools to import the package using require(). The compiled ESM syntax in will be interpreted as CommonJS by Node.js without the module type flag.